### PR TITLE
Remove output option

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,10 +38,3 @@ func read(path string) ([]byte, error) {
 	}
 	return os.ReadFile(path)
 }
-
-func writer(path string) (io.WriteCloser, error) {
-	if path == "-" {
-		return os.Stdout, nil
-	}
-	return os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0660)
-}

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/moshebe/gtrace/pkg/span"
 	"github.com/urfave/cli/v2"
@@ -11,7 +12,7 @@ import (
 
 var formatAction = func(c *cli.Context) error {
 	format := c.String("template")
-	input, output := c.String("input"), c.String("output")
+	input := c.String("input")
 
 	in, err := read(input)
 	if err != nil {
@@ -24,13 +25,7 @@ var formatAction = func(c *cli.Context) error {
 		return fmt.Errorf("unmarshal trace: %w", err)
 	}
 
-	out, err := writer(output)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = out.Close() }()
-
-	return span.Format(trace.Spans, format, out)
+	return span.Format(trace.Spans, format, os.Stdout)
 }
 
 var FormatCommand = &cli.Command{
@@ -45,12 +40,6 @@ var FormatCommand = &cli.Command{
 			Aliases: []string{"i", "in"},
 			Value:   "-",
 			Usage:   "input file path. '-' means stdin",
-		},
-		&cli.PathFlag{
-			Name:    "output",
-			Aliases: []string{"o", "out"},
-			Value:   "-",
-			Usage:   "output file path. '-' means stdout",
 		},
 		&cli.StringFlag{
 			Name:  "template",

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -13,7 +13,6 @@ import (
 
 var getAction = func(c *cli.Context) error {
 	id := c.Args().First()
-	output := c.Path("output")
 	projects := stringSlice(c, "project")
 
 	if len(projects) == 0 {
@@ -22,12 +21,6 @@ var getAction = func(c *cli.Context) error {
 	if id == "" {
 		return fmt.Errorf("missing trace id")
 	}
-
-	out, err := writer(output)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = out.Close() }()
 
 	ctx, cancel := context.WithTimeout(c.Context, time.Minute)
 	defer cancel()
@@ -54,10 +47,7 @@ var getAction = func(c *cli.Context) error {
 		return fmt.Errorf("marshal trace: %w", err)
 	}
 
-	_, err = out.Write(traceJSON)
-	if err != nil {
-		return fmt.Errorf("write trace: %w", err)
-	}
+	fmt.Println(string(traceJSON))
 
 	return nil
 }
@@ -73,12 +63,6 @@ var GetCommand = &cli.Command{
 			Name:    "project",
 			Aliases: []string{"p"},
 			Usage:   "the Google Cloud project ID to use for this invocation. values can be set multiple times or separated by comma",
-		},
-		&cli.PathFlag{
-			Name:    "output",
-			Aliases: []string{"o", "out"},
-			Value:   "-",
-			Usage:   "output file path. '-' means stdout",
 		},
 		&cli.BoolFlag{
 			Name:  "pretty",


### PR DESCRIPTION
- Remove output options from `get` and `format`

Closes #9