### PR TITLE
Add duration and subtree commands

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -20,9 +20,9 @@ jobs:
         with:
           go-version: '^1.18'
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.46.2
+          version: v1.50
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ COMMANDS:
    get      Get a specific trace by id from one or more projects
    list     Query traces from a project according to the given conditions
    url      Generate a browsable URL for a given trace
-   format   Format trace spans according to a given template
+   format   Format trace spans according to a given template      
+   duration  Filter trace spans by total duration
+   subtree   Extract span and all its children for a given trace
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -20,6 +20,8 @@ func App(version string) *cli.App {
 			ListCommand,
 			URLCommand,
 			FormatCommand,
+			DurationCommand,
+			SubtreeCommand,
 		},
 	}
 }

--- a/internal/cli/duration.go
+++ b/internal/cli/duration.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/moshebe/gtrace/pkg/span"
+	"github.com/urfave/cli/v2"
+	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var durationAction = func(c *cli.Context) error {
+	file := c.String("file")
+	min := c.Duration("min")
+
+	if min == time.Duration(0) {
+		return fmt.Errorf("missing minimum duration")
+	}
+
+	in, err := read(file)
+	if err != nil {
+		return err
+	}
+
+	var trace cloudtrace.Trace
+	err = protojson.Unmarshal(in, &trace)
+	if err != nil {
+		return fmt.Errorf("unmarshal trace: %w", err)
+	}
+
+	trace.Spans = span.FilterMinDuration(trace.Spans, min)
+
+	if c.Bool("sort") {
+		sort.Slice(trace.Spans, func(i, j int) bool {
+			return span.Duration(trace.Spans[i]) > span.Duration(trace.Spans[j])
+		})
+	}
+
+	if !c.Bool("summary") {
+		return printTraceJSON(os.Stdout, &trace)
+	}
+
+	for _, s := range trace.Spans {
+		fmt.Println(span.DurationSummary(s))
+	}
+	return nil
+}
+
+var DurationCommand = &cli.Command{
+	Name:  "duration",
+	Usage: "Filter trace spans by total duration",
+	Description: "The duration is calculated by subtracting start from the end time. Can be useful to troubleshoot " +
+		"performance or latency issues within a specific trace",
+	UsageText: "gtrace duration [command options]",
+	Action:    durationAction,
+	Flags: []cli.Flag{
+		&cli.PathFlag{
+			Name:    "file",
+			Aliases: []string{"f"},
+			Value:   "-",
+			Usage:   "input file path. '-' means stdin",
+		},
+		&cli.DurationFlag{
+			Name:  "min",
+			Value: time.Second,
+			Usage: "minimum duration threshold for filtering",
+		},
+		&cli.BoolFlag{
+			Name:  "summary",
+			Value: true,
+			Usage: "output a short summary of the results",
+		},
+		&cli.BoolFlag{
+			Name:  "sort",
+			Value: true,
+			Usage: "sort the results in descending order by span duration",
+		},
+	},
+}

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/moshebe/gtrace/pkg/span"
@@ -9,6 +10,15 @@ import (
 	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+func printTraceJSON(w io.Writer, trace *cloudtrace.Trace) error {
+	out, err := protojson.Marshal(trace)
+	if err != nil {
+		return fmt.Errorf("marshal trace: %w", err)
+	}
+	_, err = fmt.Fprint(w, string(out))
+	return err
+}
 
 var formatAction = func(c *cli.Context) error {
 	format := c.String("template")

--- a/internal/cli/subtree.go
+++ b/internal/cli/subtree.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/moshebe/gtrace/pkg/span"
+	"github.com/urfave/cli/v2"
+	"google.golang.org/genproto/googleapis/devtools/cloudtrace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var subtreeAction = func(c *cli.Context) error {
+	file := c.String("file")
+	root := c.Uint64("root")
+
+	if root == 0 {
+		return fmt.Errorf("missing root span id")
+	}
+
+	in, err := read(file)
+	if err != nil {
+		return err
+	}
+
+	var trace cloudtrace.Trace
+	err = protojson.Unmarshal(in, &trace)
+	if err != nil {
+		return fmt.Errorf("unmarshal trace: %w", err)
+	}
+	trace.Spans, err = span.SubTree(trace.Spans, root)
+	if err != nil {
+		return err
+	}
+	return printTraceJSON(os.Stdout, &trace)
+}
+
+var SubtreeCommand = &cli.Command{
+	Name:  "subtree",
+	Usage: "Extract span and all its children for a given trace",
+	Description: "Iterating the trace spans according to the original ordering and opt-out all spans that " +
+		"are not descendants the given root span",
+	UsageText: "gtrace subtree [command options]",
+	Action:    subtreeAction,
+	Flags: []cli.Flag{
+		&cli.PathFlag{
+			Name:    "file",
+			Aliases: []string{"f"},
+			Value:   "-",
+			Usage:   "input file path. '-' means stdin",
+		},
+		&cli.Uint64Flag{
+			Name:  "root",
+			Value: 0,
+			Usage: "root span id",
+		},
+	},
+}


### PR DESCRIPTION
Add two new commands:
1. duration - calculates spans durations and allow easy filter & sort to pinpoint latency issues on a specific trace
2. subtree - extract a specific span and all of its children from a trace in order to easily inspect issues within big traces